### PR TITLE
Pick up LD_LIBRARY_PATH environment variable from the R startup script

### DIFF
--- a/.vscode/debug.R
+++ b/.vscode/debug.R
@@ -1,4 +1,5 @@
 env <- Sys.getenv()
 names <- names(env)
-rnames <- names[startsWith(names, "R_")]
+rnames <- names[startsWith(names, "LD_LIBRARY")]
+rnames <- c( rnames, names[startsWith(names, "R_")] )
 writeLines(paste0(rnames, "=", env[rnames]), ".vscode/.env")

--- a/.vscode/debug.R
+++ b/.vscode/debug.R
@@ -1,5 +1,9 @@
 env <- Sys.getenv()
-names <- names(env)
-rnames <- names[startsWith(names, "LD_LIBRARY")]
-rnames <- c( rnames, names[startsWith(names, "R_")] )
-writeLines(paste0(rnames, "=", env[rnames]), ".vscode/.env")
+envnames <- names(env)
+rnames <- envnames[startsWith(envnames, "R_")]
+cached_names <- rnames
+ld_lib_path <- Sys.getenv("LD_LIBRARY_PATH")
+if (ld_lib_path != "") {
+    cached_names <- c("LD_LIBRARY_PATH", rnames)
+}
+writeLines(paste0(cached_names, "=", env[cached_names]), ".vscode/.env")

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Since `R` is not a binary executable but a bash script in which required environ
 we also need to setup those environment variables for the debugger to run the R session.
 
 `.vscode/debug.R` and `.vscode/tasks.json` are the code to capture those environment variables and to run before debugging.
+You may need, initially, to run twice in debugging mode before environment variables are properly picked up in `.vscode/.env`
 
 `.vscode/launch.json` defines the debugger configuration which in this repo works for R 3.6 under Ubuntu 16.04 or above.
 


### PR DESCRIPTION
The usual R startup script changes the environment variable LD_LIBRARY_PATH before starting the R native executable. For some setups e.g. /usr/local/lib/R/bin/exec/R installed from a source tarball, you may end up with "error while loading shared libraries: libRblas.so: cannot open shared object file: No such file or directory" .  Fix for issue #2