### PR TITLE
removing SystemRequirements: C++11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,4 +15,3 @@ LinkingTo:
     Rcpp
 Imports: 
     Rcpp
-SystemRequirements: C++11


### PR DESCRIPTION
In case #5 is an issue, I'd simply remove the line (and I *__ think__* recently `C++14` become the default anyway).