### PR TITLE
Minor polish

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ ByteCompile: TRUE
 Suggests: testthat
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
-LinkingTo: 
+LinkingTo:
     Rcpp
-Imports: 
+Imports:
     Rcpp

--- a/tests/testthat/test-calc_sum.R
+++ b/tests/testthat/test-calc_sum.R
@@ -1,5 +1,3 @@
-context("calc_sum")
-
 test_that("calc_sum works", {
   expect_equal(calc_sum(numeric()), 0)
   expect_equal(calc_sum(c(1, 2, 3)), 6)


### PR DESCRIPTION
The `warning` popped up when I was copying the `calc_sum()` function from this demo package to a new R-package where I am using `Rcpp` and setting up the `.vscode` directory as usual.

Apparently, `testthat` deprecates `testthat::context()` in the 3rd edition which I am using in this package:

![image](https://github.com/renkun-ken/vscode-rcpp-demo/assets/36898027/e9dbebff-9353-4ef9-a62f-320e2f27f734)


So I would simply remove it (it is not doing anything anyway) and also the annoying whitespaces.